### PR TITLE
Succesful login redirect fix

### DIFF
--- a/web/app/org/ada/web/controllers/AuthController.scala
+++ b/web/app/org/ada/web/controllers/AuthController.scala
@@ -91,7 +91,7 @@ class AuthController @Inject() (
           (formWithErrors: Form[(String, String)]) => BadRequest(views.html.auth.login(formWithErrors)),
           BadRequest(views.html.auth.login(loginForm.withGlobalError("Invalid user id or password"))),
           loginRedirect("User not found or locked."),
-          (userId: String) => gotoLoginSucceeded(userId, Future(Redirect(routes.AppController.dataSets())))
+          (userId: String) => gotoLoginSucceeded(userId)
         )
 
       case Accepts.Json() =>
@@ -136,7 +136,7 @@ class AuthController @Inject() (
   // immediately login as basic user
   def loginBasic = Action.async { implicit request =>
     if(userManager.debugUsers.nonEmpty)
-      gotoLoginSucceeded(userManager.basicUser.ldapDn, Future(Redirect(routes.AppController.dataSets())))
+      gotoLoginSucceeded(userManager.basicUser.ldapDn)
     else
       Future(unauthorizedRedirect)
   }
@@ -144,7 +144,7 @@ class AuthController @Inject() (
   // immediately login as admin user
   def loginAdmin = Action.async { implicit request =>
     if (userManager.debugUsers.nonEmpty)
-      gotoLoginSucceeded(userManager.adminUser.ldapDn, Future(Redirect(routes.AppController.dataSets())))
+      gotoLoginSucceeded(userManager.adminUser.ldapDn)
     else
       Future(unauthorizedRedirect)
   }

--- a/web/app/org/ada/web/security/AdaAuthConfig.scala
+++ b/web/app/org/ada/web/security/AdaAuthConfig.scala
@@ -82,7 +82,7 @@ trait AdaAuthConfig extends AuthConfig {
       if (successfulLoginUrl.isDefined && successfulLoginUrl.get.nonEmpty)
         Redirect(successfulLoginUrl.get).withSession("successfulLoginUrl" -> "")
       else
-        Redirect(routes.UserProfileController.profile())
+        Redirect(routes.AppController.dataSets())
     )
   }
 


### PR DESCRIPTION
Preserving an original URL (while promoting for login) with AppController.dataSets used as a land page only when no other provided.

Relates to ada-discovery/ada-issues#146